### PR TITLE
Make verbose level configurable and lower it.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ ENV DB_PORT=3306 \
     DB_USER="" \
     DO_UPLOAD="1" \
     GCS_BUCKET_NAME="" \
-    BACKUP_KEY=""
+    BACKUP_KEY="" \
+    MYDUMPER_VERBOSE_LEVEL="1"
 
 ENTRYPOINT [ "/app/entrypoint.sh" ]

--- a/src/backup.sh
+++ b/src/backup.sh
@@ -12,7 +12,7 @@ mydumper --user="$DB_USER" \
          --password="$DB_PASSWORD" \
          --outputdir="$BACKUP_DIR" \
          --trx-consistency-only \
-         --verbose=3
+         --verbose="$MYDUMPER_VERBOSE_LEVEL"
 
 cat "$BACKUP_DIR"/metadata
 

--- a/src/restore.sh
+++ b/src/restore.sh
@@ -8,4 +8,4 @@ myloader --user="$DB_USER" \
          --host="$DB_HOST" \
          --password="$DB_PASSWORD" \
          --directory="$BACKUP_RESTORE_DIR" \
-         --verbose=3
+         --verbose="$MYDUMPER_VERBOSE_LEVEL"


### PR DESCRIPTION
Level 3 is a bit too high and makes detecting errors/critical output hard.
Excessive logging will just cost money in the long run.