### PR TITLE
1. Add file validation and check for replica lag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN useradd -u 1234 notroot && \
     chown notroot /backups /mnt/backup-bucket && \
     apt-get update && apt-get install --yes --no-install-recommends \
     ca-certificates=20210119~18.04.2 \
-    curl=7.58.0-2ubuntu3.16 \
+    curl=7.58.0-2ubuntu3.17 \
     gnupg=2.2.4-1ubuntu1.4 \
     mydumper=0.9.1-5 \
     mariadb-client=1:10.1.48-0ubuntu0.18.04.1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ RUN useradd -u 1234 notroot && \
     curl=7.58.0-2ubuntu3.16 \
     gnupg=2.2.4-1ubuntu1.4 \
     mydumper=0.9.1-5 \
+    mariadb-client=1:10.1.48-0ubuntu0.18.04.1 \
   && echo "deb http://packages.cloud.google.com/apt $GCSFUSE_REPO main" \
     | tee /etc/apt/sources.list.d/gcsfuse.list \
   && curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
@@ -30,6 +31,10 @@ ENV DB_PORT=3306 \
     DO_UPLOAD="1" \
     GCS_BUCKET_NAME="" \
     BACKUP_KEY="" \
-    MYDUMPER_VERBOSE_LEVEL="1"
+    MYDUMPER_VERBOSE_LEVEL="1" \
+    EXPECTED_FILES="" \
+    REPLICATION_THRESHOLD=60 \
+    SECONDARY_HOST=sql-mariadb-secondary.default.svc.cluster.local \
+    DO_CHECK_SECONDARY="1"
 
 ENTRYPOINT [ "/app/entrypoint.sh" ]

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -58,6 +58,8 @@ services:
       - DB_PORT=3306
       - DO_UPLOAD=0
       - BACKUP_KEY=abc123
+      - EXPECTED_FILES=metadata,my_wiki.page.sql,my_wiki.page-schema.sql
+      - DO_CHECK_SECONDARY=0
     volumes:
       - ./backup-outputs:/backups:rw
 

--- a/src/backup.sh
+++ b/src/backup.sh
@@ -14,8 +14,8 @@ mydumper --user="$DB_USER" \
          --trx-consistency-only \
          --verbose="$MYDUMPER_VERBOSE_LEVEL"
 
-cat "$BACKUP_DIR"/metadata
+bash "$ROOT/validate_expected_files.sh" "$BACKUP_DIR"
 
 cd "$BACKUP_DIR"
-bash "$ROOT"/compress_folder.sh "$BACKUP_ARCHIVE"
+bash "$ROOT/compress_folder.sh" "$BACKUP_ARCHIVE"
 cd -

--- a/src/check_secondary_status.sh
+++ b/src/check_secondary_status.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+SECONDS_BEHIND=$(mysql -e "show slave status\G" --host="$SECONDARY_HOST" --port="$DB_PORT" -u"$DB_USER" -p"$DB_PASSWORD" | grep "Seconds_Behind_Master" | awk '{print $2}')
+SECONDS_BEHIND=${SECONDS_BEHIND%.*}
+
+if [[ $SECONDS_BEHIND = "NULL" ]]; then
+    echo "Replication isn't running yet got NULL seconds behind primary!"
+    exit 1;
+elif [[ ${SECONDS_BEHIND} =~ ^-?[0-9]+$ && $REPLICATION_THRESHOLD -gt ${SECONDS_BEHIND} ]]; then
+    exit 0;
+else
+    echo "More than $REPLICATION_THRESHOLD seconds behind primary"
+    exit 1;
+fi

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -e
 
+if [ "$DO_CHECK_SECONDARY" -eq "1" ]; then
+    ./check_secondary_status.sh
+else
+    echo "Skip checking secondary..."
+fi
+
 ./backup.sh
 
 ## GCS bucket is mounted by chart

--- a/src/validate_expected_files.sh
+++ b/src/validate_expected_files.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+set -e
+
+BACKUP_ROOT=$1
+FINAL_EXPECTED_FILES=()
+DEFAULT_EXPECTED_FILES=( \
+		"metadata" \
+        "apidb.users.sql" \
+        "apidb.users-schema.sql" \
+        "apidb.wikis.sql" \
+        "apidb.wikis-schema.sql" \
+        "mysql.db.sql" \
+        "mysql.db-schema.sql"
+		)
+
+# allow overriding expected files
+if [[ -z "${EXPECTED_FILES// }" ]]; then
+    FINAL_EXPECTED_FILES=("${DEFAULT_EXPECTED_FILES[@]}") 
+else
+    IFS=', ' read -r -a FINAL_EXPECTED_FILES <<< "$EXPECTED_FILES"
+fi
+
+for EXPECTED in "${FINAL_EXPECTED_FILES[@]}"; do
+    FILE="$BACKUP_ROOT/$EXPECTED"
+    if [[ -f "$FILE" && -s "$FILE" ]]; then
+        echo "$FILE exists!"
+    else
+        echo "$FILE does not exist or is empty!"
+        exit 1
+    fi
+done


### PR DESCRIPTION
This adds validate_expected_files.sh that checks for existing and
non-empty files.

This also adds check_secondary_status.sh to confirm that the replica
isn't lagged just before we take a backup.