### PR TITLE
Do all backups under /backups + add cleanup script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,11 @@ ENV GCSFUSE_REPO gcsfuse-bionic
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN useradd -u 1234 notroot && \
-    mkdir /backups && mkdir -p /mnt/backup-bucket && \
-    chown notroot /backups /mnt/backup-bucket && \
+    mkdir -p /backups/tmp && \
+    mkdir -p /backups/output && \
+    mkdir -p /mnt/backup-bucket && \
+    chown notroot /backups -R && \
+    chown notroot /mnt/backup-bucket && \
     apt-get update && apt-get install --yes --no-install-recommends \
     ca-certificates=20210119~18.04.2 \
     curl=7.58.0-2ubuntu3.17 \

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -56,12 +56,12 @@ services:
       - DB_PASSWORD=${DB_PASS}
       - DB_HOST=mysql.svc
       - DB_PORT=3306
-      - DO_UPLOAD=0
+      - DO_UPLOAD=1
       - BACKUP_KEY=abc123
       - EXPECTED_FILES=metadata,my_wiki.page.sql,my_wiki.page-schema.sql
       - DO_CHECK_SECONDARY=0
     volumes:
-      - ./backup-outputs:/backups/output:rw
+      - ./backup-outputs:/mnt/backup-bucket/:rw
 
 volumes:
   mediawiki-mysql-data:

--- a/ci/docker-compose.yml
+++ b/ci/docker-compose.yml
@@ -61,7 +61,7 @@ services:
       - EXPECTED_FILES=metadata,my_wiki.page.sql,my_wiki.page-schema.sql
       - DO_CHECK_SECONDARY=0
     volumes:
-      - ./backup-outputs:/backups:rw
+      - ./backup-outputs:/backups/output:rw
 
 volumes:
   mediawiki-mysql-data:

--- a/src/backup.sh
+++ b/src/backup.sh
@@ -3,8 +3,8 @@ set -e
 
 ROOT=$PWD
 TIMESTAMP=$(date '+%Y-%m-%d_%H%M%S')
-BACKUP_DIR=/tmp/backup-"$TIMESTAMP"
-BACKUP_ARCHIVE=/backups/"mydumper-backup-$TIMESTAMP".tar.gz
+BACKUP_DIR=/backups/tmp/backup-"$TIMESTAMP"
+BACKUP_ARCHIVE=/backups/output/"mydumper-backup-$TIMESTAMP".tar.gz
 
 mydumper --user="$DB_USER" \
          --port="$DB_PORT" \

--- a/src/cleanup.sh
+++ b/src/cleanup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -e
+
+rm -rf /backups/output/*
+rm -rf /backups/tmp/*

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -16,3 +16,5 @@ if [ "$DO_UPLOAD" -eq "1" ]; then
 else
     echo "Skip uploading..."
 fi
+
+./cleanup.sh

--- a/src/entrypoint.sh
+++ b/src/entrypoint.sh
@@ -12,7 +12,7 @@ fi
 ## GCS bucket is mounted by chart
 # We can just move the artifacts
 if [ "$DO_UPLOAD" -eq "1" ]; then
-    mv /backups/* /mnt/backup-bucket/
+    mv /backups/output/* /mnt/backup-bucket/
 else
     echo "Skip uploading..."
 fi


### PR DESCRIPTION
everything will now happen under /backups

- Stops using the raw files for validating in CI
- enables DO_UPLOAD to move the files to the docker mount for CI