### PR TITLE
Don't use * to compress + pipefail 

### DIFF
--- a/src/backup.sh
+++ b/src/backup.sh
@@ -19,6 +19,4 @@ mydumper --user="$DB_USER" \
 
 bash "$ROOT/validate_expected_files.sh" "$BACKUP_DIR"
 
-cd "$BACKUP_DIR"
-bash "$ROOT/compress_folder.sh" "$BACKUP_ARCHIVE"
-cd -
+bash "$ROOT/compress_folder.sh" "$BACKUP_DIR" "$BACKUP_ARCHIVE"

--- a/src/check_secondary_status.sh
+++ b/src/check_secondary_status.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -o pipefail
 
 SECONDS_BEHIND=$(mysql -e "show slave status\G" --host="$SECONDARY_HOST" --port="$DB_PORT" -u"$DB_USER" -p"$DB_PASSWORD" | grep "Seconds_Behind_Master" | awk '{print $2}')
 SECONDS_BEHIND=${SECONDS_BEHIND%.*}

--- a/src/compress_folder.sh
+++ b/src/compress_folder.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 set -e
+set -o pipefail
 
-tar -czf - ./* | openssl enc -pbkdf2 -pass "pass:$BACKUP_KEY" -e -aes256 -out "$1"
+INPUT_DIR=$1
+OUTPUT_FILE=$2
+tar -cz -C "$INPUT_DIR" . | openssl enc -pbkdf2 -pass "pass:$BACKUP_KEY" -e -aes256 -out "$OUTPUT_FILE"

--- a/src/decompress_archive.sh
+++ b/src/decompress_archive.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -o pipefail
 
 # example: BACKUP_KEY=asdf ./decompress_archive.sh /backups/mydumper-backup-2022-03-18_122503.tar.gz /tmp/outdir
 mkdir -p "$2"


### PR DESCRIPTION
Don't compress with ./* as this overflows the arguments when compressing.

Add pipefail to stuff that could use it.