### PR TITLE
restore.sh: overwrite tables

### DIFF
--- a/src/restore.sh
+++ b/src/restore.sh
@@ -8,4 +8,5 @@ myloader --user="$DB_USER" \
          --host="$DB_HOST" \
          --password="$DB_PASSWORD" \
          --directory="$BACKUP_RESTORE_DIR" \
+         --overwrite-tables \
          --verbose="$MYDUMPER_VERBOSE_LEVEL"


### PR DESCRIPTION
This adds the `--overwrite-tables` flag to `restore.sh`. We probably want this in most restore scenarios.
