### PR TITLE
DNM - test: use same filename for backups

### DIFF
--- a/src/backup.sh
+++ b/src/backup.sh
@@ -9,6 +9,8 @@ TIMESTAMP=$(date '+%Y-%m-%d_%H%M%S')
 BACKUP_DIR=/backups/tmp/backup-"$TIMESTAMP"
 BACKUP_ARCHIVE=/backups/output/mydumper-backup.tar.gz
 
+df -h
+
 mydumper --user="$DB_USER" \
          --port="$DB_PORT" \
          --host="$DB_HOST" \
@@ -20,3 +22,5 @@ mydumper --user="$DB_USER" \
 bash "$ROOT/validate_expected_files.sh" "$BACKUP_DIR"
 
 bash "$ROOT/compress_folder.sh" "$BACKUP_DIR" "$BACKUP_ARCHIVE"
+
+df -h

--- a/src/backup.sh
+++ b/src/backup.sh
@@ -7,7 +7,7 @@ mkdir -p /backups/output
 ROOT=$PWD
 TIMESTAMP=$(date '+%Y-%m-%d_%H%M%S')
 BACKUP_DIR=/backups/tmp/backup-"$TIMESTAMP"
-BACKUP_ARCHIVE=/backups/output/"mydumper-backup-$TIMESTAMP".tar.gz
+BACKUP_ARCHIVE=/backups/output/mydumper-backup.tar.gz
 
 mydumper --user="$DB_USER" \
          --port="$DB_PORT" \


### PR DESCRIPTION
In an attempt to see how GCP buckets behave if we use the same filename every time, in order to be more flexible with the file retainment policy (e.g. if the file is versioned automatically, we could take advantage of that)